### PR TITLE
upgrade to 7.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,12 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:7.3.0"
+    classpath "org.elasticsearch.gradle:build-tools:7.3.1"
   }
 }
 
 group = 'com.o19s'
-version = '1.1.1-es7.3.0'
+version = '1.1.2-es7.3.1'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -51,10 +51,10 @@ dependencies {
   compile 'org.ow2.asm:asm:5.0.4'
   compile 'org.ow2.asm:asm-commons:5.0.4'
   compile 'org.ow2.asm:asm-tree:5.0.4'
-  compile 'org.elasticsearch:elasticsearch:7.3.0'
+  compile 'org.elasticsearch:elasticsearch:7.3.1'
   compile 'com.o19s:RankyMcRankFace:0.1.1'
   compile "com.github.spullara.mustache.java:compiler:0.9.3"
-  testCompile 'org.elasticsearch.test:framework:7.3.0'
+  testCompile 'org.elasticsearch.test:framework:7.3.1'
 
 }
 
@@ -65,11 +65,13 @@ dependencyLicenses {
   mapping from: /compiler-.*/, to: 'lucene'
 }
 
-configurations.all {
-  resolutionStrategy.dependencySubstitution {
-    substitute project(':rest-api-spec') with module ("org.elasticsearch:rest-api-spec:7.3.0")
-  }
+
+// https://github.com/elastic/elasticsearch/issues/45891#issuecomment-525399411
+configurations.restSpec.withDependencies { dependencies ->
+  dependencies.clear()
+  dependencies.add(project.dependencies.create("org.elasticsearch:rest-api-spec:7.3.1"))
 }
+
 
 // Set to false to not use elasticsearch checkstyle rules
 checkstyleMain.enabled = true


### PR DESCRIPTION
updated the es_7_3 pr to 7.3.1

also added a workaround for rest-api-spec as suggested [here](https://github.com/elastic/elasticsearch/issues/45891#issuecomment-525399411)

Note, we're in the middle of a migration to 7.3.1 so it would be nice to get this in either via this PR to your PR (https://github.com/o19s/elasticsearch-learning-to-rank/pull/238) or a separate release in case you need a 7.3.0 release as well.